### PR TITLE
Import Buffer from 'buffer'

### DIFF
--- a/src/crypto/blake256.js
+++ b/src/crypto/blake256.js
@@ -1,3 +1,5 @@
+import {Buffer} from 'buffer'
+
 /**
  * Credits to https://github.com/cryptocoinjs/blake-hash
  */


### PR DESCRIPTION
My environment doesn't have global `Buffer`. If `multichain-address-validator` will import `Buffer` from `buffer` package then global `Buffer` polyfill will not be required. Then I'll can to remove:

```
import {Buffer} from 'buffer';
global.Buffer = Buffer;
```
